### PR TITLE
Mobile: Loads the Records List

### DIFF
--- a/mobile/lib/models/record_model.dart
+++ b/mobile/lib/models/record_model.dart
@@ -1,17 +1,47 @@
 import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui';
 
 class RecordModel {
   const RecordModel({
-    required this.dateEntered, 
-    required this.balance,
+    required this.createdAt, 
+    required this.amount,
     required this.reason,
     required this.receipt,
     required this.signature
   });
 
-  final DateTime dateEntered;
+  final DateTime createdAt;
   final String reason;
-  final double balance;
-  final File? receipt;
-  final File? signature;
+  final double amount;
+  final Map<String, dynamic> receipt;
+  final String signature;
+
+  bool hasReceipt() {
+    dynamic receiptValue = receipt['data'];
+    if(receiptValue is List) {
+      return receiptValue.isNotEmpty;
+    }
+    return false;
+  }
+
+  factory RecordModel.fromJson(Map<String, dynamic> json) {
+    dynamic amountJson = json['amount'];
+    double amountValue;
+    if(amountJson is int) {
+      amountValue = amountJson.toDouble();
+    } else if(amountJson is double) {
+      amountValue = amountJson;
+    } else {
+      amountValue = 0;
+    }
+
+    return RecordModel(
+      createdAt: DateTime.parse(json['createdAt']),
+      reason: json['reason'],
+      amount: amountValue,
+      receipt: json['receipt'],
+      signature: json['signature'],
+    );
+  }
 }

--- a/mobile/lib/screens/record_list.dart
+++ b/mobile/lib/screens/record_list.dart
@@ -1,8 +1,10 @@
-import 'dart:io';
+import 'dart:collection';
 
 import 'package:flutter/material.dart';
 import 'package:mobile/models/record_model.dart';
 import 'package:mobile/screens/record_tile.dart';
+import 'package:mobile/services/record_service.dart';
+import 'package:mobile/services/result.dart';
 
 enum RecordActions { showReceipt, showSignature, edit, delete, sync }
 
@@ -14,10 +16,34 @@ class RecordList extends StatefulWidget {
 }
 
 class _RecordListState extends State<RecordList> {
-  static List<RecordModel> records = [
-    RecordModel(dateEntered: DateTime(2024, 5, 12), balance: 120, reason: 'Office Supplies Again', receipt: File(''), signature: null),
-    RecordModel(dateEntered: DateTime(2024, 5, 9), balance: 100, reason: 'Office Supplies', receipt: null, signature: File(''))
-  ];
+  final TextEditingController guidController = TextEditingController();
+  late Future<List<RecordModel>> futureRecords = Future.value([]);
+  late Queue<Exception>? errors = Queue();
+  String guid = "";
+
+  @override
+  void initState() {
+    super.initState();
+    fetchRecords();
+  }
+
+  Future<void> fetchRecords() async {
+    Result<bool> isValidGuid = await RecordService().isPublicGuid(guid);
+    errors = isValidGuid.exceptions;
+
+    setState(() {
+      if(!isValidGuid.value) {
+        futureRecords = Future.value([]);
+      } else {
+        futureRecords = RecordService().fetchRecords(guid);
+      }
+    });
+  }
+
+  void onGuidChange() {
+    guid = guidController.text.trim();
+    fetchRecords();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,9 +51,73 @@ class _RecordListState extends State<RecordList> {
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Text('Record List'),
+        actions: [
+          IconButton(onPressed: () => showDialog(context: context, 
+            builder: (BuildContext context) => Dialog(
+                        child: Padding(
+                          padding: const EdgeInsets.all(5.0),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              TextField(
+                                controller: guidController,
+                                decoration: InputDecoration(
+                                  hintText: 'Input Records GUID here',
+                                ),
+                              ),
+                              TextButton(
+                                onPressed: () {
+                                  onGuidChange();
+                                  Navigator.pop(context);
+                                },
+                                child: const Text('Close'),
+                              ),
+                            ],
+                          ),
+                        )
+            )), 
+            icon: Icon(Icons.vpn_key))
+        ],
       ),
-      body: ListView(
-        children: records.map((record) => RecordTile(record: record)).toList()
+      body: FutureBuilder<List<RecordModel>>(
+        future: futureRecords, 
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (errors!.isNotEmpty) {
+            return Center(child: Text('${errors!.first}'));
+          }
+
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final records = snapshot.data!;
+
+          if (records.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [ 
+                  Text('No Records Found'),
+                  OutlinedButton(
+                    onPressed: fetchRecords,
+                    child: Text('Refresh'),
+                  )
+                ]
+              )
+            );
+          }
+        
+          return RefreshIndicator(
+            onRefresh: fetchRecords,
+            child: ListView(
+              children: records.map((record) => RecordTile(record: record)).toList()
+            ) 
+          );
+        }
       )
     );
   }

--- a/mobile/lib/services/record_service.dart
+++ b/mobile/lib/services/record_service.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:mobile/models/record_model.dart';
+import 'package:mobile/services/result.dart';
+import 'package:mobile/utils/api_paths.dart';
+
+class RecordService {
+  Future<List<RecordModel>> fetchRecords(String guid) async {
+    final response = await http.post(Uri.http(ApiPaths.baseUrl, ApiPaths.recordListUrl), 
+      body: {
+        'guid': guid
+      }
+    );
+
+    if (response.statusCode == 200) {
+      final List<dynamic> jsonList = jsonDecode(response.body);
+      return jsonList.map((e) => RecordModel.fromJson(e)).toList();
+    } 
+    else if(response.statusCode == 404) {
+      return [];
+    }
+    else {
+      throw Exception('Failed to load records');
+    }
+  }
+
+  Future<Result<bool>> isPublicGuid(String guid) async {
+    Result<bool> result = Result(false);
+    if(guid.isEmpty) {
+      result.exceptions.add(Exception("No GUID yet, please set it by clicking the Key button"));
+      return Future.value(result);
+    }
+
+    final response = await http.post(Uri.http(ApiPaths.baseUrl, ApiPaths.isPublicGuidUrl), 
+      body: {
+        'guid': guid
+      }
+    );
+
+    if (response.statusCode == 200) {
+      result.value = response.body.toLowerCase() == 'true';
+      if(!result.value) {
+        result.exceptions.add(Exception('Not a valid GUID'));
+      }
+    } 
+    else {
+      result.exceptions.add(Exception('Not a valid GUID'));
+    }
+    
+    return result;
+  }
+}

--- a/mobile/lib/services/result.dart
+++ b/mobile/lib/services/result.dart
@@ -1,0 +1,8 @@
+import 'dart:collection';
+
+class Result<T> {
+  late T value;
+  Queue<Exception> exceptions = Queue();
+
+  Result(this.value);
+}

--- a/mobile/lib/utils/api_paths.dart
+++ b/mobile/lib/utils/api_paths.dart
@@ -1,0 +1,8 @@
+class ApiPaths {
+  ApiPaths._();
+
+  static const String recordListUrl = "api/record/recordList";
+  static const String isPublicGuidUrl = "api/audit/isPublicGuid";
+
+  static const String baseUrl = "10.0.2.2:3000";
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -75,6 +75,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   intl:
     dependency: "direct main"
     description:
@@ -200,6 +216,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -216,6 +240,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
   dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   intl: ^0.20.2
+  http: ^1.4.0
 
 dev_dependencies:
   flutter_test:

--- a/web/src/components/pages/records/recordCrud.tsx
+++ b/web/src/components/pages/records/recordCrud.tsx
@@ -8,6 +8,7 @@ import { SignatureDialog } from "../../ui/signatureDialog";
 import { Edit, SquareArrowOutUpRight, SquarePen, Trash } from "lucide-react";
 import { RecordAddReceiptSignatureDialog } from "./recordAddReceiptSignatureDialog";
 import { RecordRow } from "./recordRow";
+import AuditRecord from "@/models/AuditRecord";
 
 export default function RecordCrud({ guid }: { guid: string }) {
     const [addBalanceInput, setBalanceInput] = useState("");
@@ -37,16 +38,17 @@ export default function RecordCrud({ guid }: { guid: string }) {
             .then((dataList) => {
                 let currentBalance: number | null = null
                 dataList.forEach((currentValue: {
-                    dateCreated: Date;
-                    dateCreatedEpoch: number; amount: number | null; runningBalance: number | null; 
-}) => {
+                    createdAt: Date;
+                    amount: number | null; 
+                    runningBalance: number | null; 
+                    }) => {
                     if(!currentBalance) {
                         currentBalance = currentValue.amount
                     } else {
                         currentBalance += currentValue.amount ?? 0
                     }
                     currentValue.runningBalance = currentBalance
-                    currentValue.dateCreated = new Date(currentValue.dateCreatedEpoch * 1000)
+                    currentValue.createdAt = new Date(currentValue.createdAt)
                 })
                 setCurrentBalance(currentBalance ?? 0);
                 setRecordList(dataList)
@@ -136,7 +138,7 @@ export default function RecordCrud({ guid }: { guid: string }) {
                     <tbody>
                         {recordList?.length > 0 ? (
                             recordList?.map((audit) => (
-                                <RecordRow audit={audit} onEditSuccess={fetchRecords} onDeleteSuccess={fetchRecords}></RecordRow>
+                                <RecordRow key={audit.id} audit={audit} onEditSuccess={fetchRecords} onDeleteSuccess={fetchRecords}></RecordRow>
                             ))
                         ) : (
                             <tr>

--- a/web/src/components/pages/records/recordRow.tsx
+++ b/web/src/components/pages/records/recordRow.tsx
@@ -78,7 +78,7 @@ export function RecordRow({
         )}
       </td>
       <td>{audit.runningBalance}</td>
-      <td>{audit.dateCreated.toLocaleString()}</td>
+      <td>{audit.createdAt.toLocaleString()}</td>
       <td>
         <Button className="bg-sky-400">
           <SquareArrowOutUpRight />

--- a/web/src/models/AuditRecord.ts
+++ b/web/src/models/AuditRecord.ts
@@ -4,8 +4,7 @@ interface AuditRecord {
     signature: string | null;
     id: number;
     amount: number;
-    dateCreatedEpoch: number;
-    dateCreated: Date;
+    createdAt: Date;
     hasReceipt: boolean;
     hasSignature: boolean;
     runningBalance: number;


### PR DESCRIPTION
How to use: (Errors should guide ideally)
1. Click the key button on the top right to enter the GUID of the records page
2. Records should load

Currently implemented features:
1. Scroll down to reload
2. Empty Records shows a message with a Refresh button
3. The trailing buttons on each entry will show the 'Show Receipt' and 'Show Signature' menu buttons only if such info exists
4. Show Receipt and Show Signature button shows a popup

Web related changes:
1. Fixed Audit to use createdAt instead of dateCreated to match the property returned by the Service. (Records list won't show Invalid Date anymore)